### PR TITLE
fix: rename podSpecHash function

### DIFF
--- a/internal/controller/qworker_controller.go
+++ b/internal/controller/qworker_controller.go
@@ -65,12 +65,12 @@ func (r *QWorkerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	qworker.Status.CurrentReplicas = currentPodCount
 
 	// Generate the hash for the pod template
-	podTemplateHash, err := GeneratePodTemplateHash(qworker.Spec.PodSpec)
+	podSpecHash, err := GeneratePodSpecHash(qworker.Spec.PodSpec)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
 
-	qworker.Status.CurrentPodSpecHash = podTemplateHash
+	qworker.Status.CurrentPodSpecHash = podSpecHash
 
 	if err = r.Status().Update(ctx, qworker); err != nil {
 		log.Log.Error(err, fmt.Sprintf("Failed to update QWorker status %s", qworker.Name))

--- a/internal/controller/utils.go
+++ b/internal/controller/utils.go
@@ -9,8 +9,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/json"
 )
 
-// GeneratePodTemplateHash generates a deterministic hash for a pod template
-func GeneratePodTemplateHash(podSpec corev1.PodSpec) (string, error) {
+// GeneratePodSpecHash generates a deterministic hash for a pod template
+func GeneratePodSpecHash(podSpec corev1.PodSpec) (string, error) {
 	// Serialize the pod spec to JSON
 	podSpecBytes, err := json.Marshal(podSpec)
 	if err != nil {

--- a/internal/controller/utils_test.go
+++ b/internal/controller/utils_test.go
@@ -11,7 +11,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-// TestGeneratePodTemplateHash tests the GeneratePodTemplateHash function
+// TestGeneratePodTemplateHash tests the GeneratePodSpecHash function
 func TestGeneratePodTemplateHash(t *testing.T) {
 	// Define a sample PodSpec for testing
 	podSpec := corev1.PodSpec{
@@ -36,9 +36,9 @@ func TestGeneratePodTemplateHash(t *testing.T) {
 	expectedHashString := hex.EncodeToString(expectedHash[:])
 
 	// Call the function under test
-	actualHash, err := GeneratePodTemplateHash(podSpec)
+	actualHash, err := GeneratePodSpecHash(podSpec)
 	if err != nil {
-		t.Fatalf("GeneratePodTemplateHash returned an error: %v", err)
+		t.Fatalf("GeneratePodSpecHash returned an error: %v", err)
 	}
 
 	// Verify the result
@@ -62,21 +62,21 @@ func TestGeneratePodTemplateHash_Deterministic(t *testing.T) {
 		},
 	}
 
-	// Run GeneratePodTemplateHash twice with the same input
-	hash1, err1 := GeneratePodTemplateHash(podSpec)
-	hash2, err2 := GeneratePodTemplateHash(podSpec)
+	// Run GeneratePodSpecHash twice with the same input
+	hash1, err1 := GeneratePodSpecHash(podSpec)
+	hash2, err2 := GeneratePodSpecHash(podSpec)
 
 	// Assert no errors
 	if err1 != nil {
-		t.Fatalf("First call to GeneratePodTemplateHash() returned error: %v", err1)
+		t.Fatalf("First call to GeneratePodSpecHash() returned error: %v", err1)
 	}
 	if err2 != nil {
-		t.Fatalf("Second call to GeneratePodTemplateHash() returned error: %v", err2)
+		t.Fatalf("Second call to GeneratePodSpecHash() returned error: %v", err2)
 	}
 
 	// Assert the hashes are equal
 	if hash1 != hash2 {
-		t.Errorf("GeneratePodTemplateHash() returned different results: hash1 = %v, hash2 = %v", hash1, hash2)
+		t.Errorf("GeneratePodSpecHash() returned different results: hash1 = %v, hash2 = %v", hash1, hash2)
 	} else {
 		t.Logf("Hashes match: %v", hash1)
 	}


### PR DESCRIPTION
- **fix: rewrite secret manager (#21)**
- **feat: added worker serviceaccount and rbac (#26)**
- **feat: pass qworker name to pod (#28)**
- **feat: add pod label hash (#29)**
- **feat: add metrics server (#24)**
- **rename function**
